### PR TITLE
Fixes "Could not create SSL/TLS secure channel."

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -6,6 +6,7 @@ if ($isLinux) {
 }
 
 $zipPath = Join-Path $temp 'secure-file.zip'
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
 (New-Object Net.WebClient).DownloadFile('https://github.com/appveyor/secure-file/releases/download/1.0.0/secure-file.zip', $zipPath)
 Expand-Archive $zipPath -DestinationPath (Join-Path (pwd).path "appveyor-tools")
 if ($isLinux) {


### PR DESCRIPTION
Hello!

I am having an issue with the PowerShell script: when run from Windows 10, because PowerShell uses by default TLS 1.0, the script will fail on the `DownloadFile` function

![image](https://user-images.githubusercontent.com/10530980/38566526-2d134be6-3ce4-11e8-8d1c-847cfb850df2.png)

My custom translation:
> Exception while calling «DownloadFile» with «2» argument(s): «The request was aborted: Could not create SSL/TLS secure channel.»

After looking a bit on the internet, I found out that this could be fixed by explicitly specifying a preference TLS order, such as in the following changes.

After the change:
![image](https://user-images.githubusercontent.com/10530980/38567198-e3e9f148-3ce5-11e8-9c51-5155e4c8054d.png)

Disclaimer: this is not supported on Windows XP (i tested it), but so is `Expand-Archive` (two lines after), so this script isnt already working on it.

Calling @FeodorFitsner for review :)