### PR TITLE
Resolves issue #2 - Why static salt?

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ High-level scenario of using this utility in [AppVeyor CI](http://www.appveyor.c
 
 - Encrypt file on development machine.
 - Commit encrypted file to source control.
-- Place "secret" and "salt" within a project environment variable.
+- Place "secret" and "salt" within a secure environment variables.
 - Decrypt file during the build.
 
 System requirements:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ High-level scenario of using this utility in [AppVeyor CI](http://www.appveyor.c
 
 - Encrypt file on development machine.
 - Commit encrypted file to source control.
-- Place "secret" to project environment variable.
+- Place "secret" and "salt" within a project environment variable.
 - Decrypt file during the build.
 
 System requirements:

--- a/README.md
+++ b/README.md
@@ -32,19 +32,21 @@ To encrypt on Linux:
 
     ./appveyor-tools/secure-file -encrypt /path-to/filename-to-encrypt.ext -secret MYSECRET1234
 
-Encrypted file will be saved in the same directory as the input file, but with the `.enc` extension added. You can optionally specify output file name with the `-out` parameter.
+Encrypted file will be saved in the same directory as the input file, but with the `.enc` extension added. You can optionally specify output file name with the `-out` parameter. Also, when encrypting the application will output the salt generated to the console so it can be stored.
 
 After that commit the encrypted file to source control.
 
 
 ## Decrypting files during an AppVeyor build
 
-Put the "secret" value to the project environment variables on the _Environment_ tab of the project settings or in the `appveyor.yml` as a [secure variable](https://ci.appveyor.com/tools/encrypt):
+Put the "secret" value and the Base64 encoded "salt" value to the project environment variables on the _Environment_ tab of the project settings or in the `appveyor.yml` as a [secure variable](https://ci.appveyor.com/tools/encrypt):
 
 ```
 environment:
   my_secret:
     secure: BSNfEghh/l4KAC3jAcwAjgTibl6UHcZ08ppSFBieQ8E=
+  my_salt:
+    secure: H/jNH0Wk6Vs7yLu2BDGCve/8VpHrK54Ry7WTPRqf0OKPeFMPY/qxAD0HDY/2lECY6xOS40LozjLgtLkAZdPdHg==
 ```
 
 To decrypt the file, add these lines to the `install` section of your project config:
@@ -52,8 +54,8 @@ To decrypt the file, add these lines to the `install` section of your project co
 ```
 install:
   - ps: iex ((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/appveyor/secure-file/master/install.ps1'))
-  - cmd: appveyor-tools\secure-file -decrypt path-to\encrypted-filename.ext.enc -secret %my_secret%
-  - sh: ./appveyor-tools/secure-file -decrypt path-to/encrypted-filename.ext.enc -secret $my_secret
+  - cmd: appveyor-tools\secure-file -decrypt path-to\encrypted-filename.ext.enc -secret %my_secret% -salt %my_salt%
+  - sh: ./appveyor-tools/secure-file -decrypt path-to/encrypted-filename.ext.enc -secret $my_secret -salt $my_salt
 ```
 
 The line starting with `cmd:` will run on Windows-based images only and the line starting with `sh:` on Linux.

--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,7 @@ New-Item -ItemType Directory -Path $tempdir
 
 $zipPath = Join-Path $tempdir 'secure-file.zip'
 [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-(New-Object Net.WebClient).DownloadFile('https://github.com/jeff-winn/secure-file/releases/download/1.1.0/secure-file.zip', $zipPath)
+(New-Object Net.WebClient).DownloadFile('https://github.com/jeff-winn/secure-file/releases/download/1.1.1/secure-file.zip', $zipPath)
 Expand-Archive $zipPath -DestinationPath (Join-Path (pwd).path "appveyor-tools") -Force
 if ($isLinux) {
 	chmod +x ./appveyor-tools/secure-file

--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,7 @@ New-Item -ItemType Directory -Path $tempdir
 
 $zipPath = Join-Path $tempdir 'secure-file.zip'
 [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-(New-Object Net.WebClient).DownloadFile('https://github.com/appveyor/secure-file/releases/download/1.0.0/secure-file.zip', $zipPath)
+(New-Object Net.WebClient).DownloadFile('https://github.com/jeff-winn/secure-file/releases/download/1.1.1/secure-file.zip', $zipPath)
 Expand-Archive $zipPath -DestinationPath (Join-Path (pwd).path "appveyor-tools") -Force
 if ($isLinux) {
 	chmod +x ./appveyor-tools/secure-file

--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,7 @@ New-Item -ItemType Directory -Path $tempdir
 
 $zipPath = Join-Path $tempdir 'secure-file.zip'
 [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-(New-Object Net.WebClient).DownloadFile('https://github.com/jeff-winn/secure-file/releases/download/1.1.1/secure-file.zip', $zipPath)
+(New-Object Net.WebClient).DownloadFile('https://github.com/appveyor/secure-file/releases/download/1.0.0/secure-file.zip', $zipPath)
 Expand-Archive $zipPath -DestinationPath (Join-Path (pwd).path "appveyor-tools") -Force
 if ($isLinux) {
 	chmod +x ./appveyor-tools/secure-file

--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,7 @@ New-Item -ItemType Directory -Path $tempdir
 
 $zipPath = Join-Path $tempdir 'secure-file.zip'
 [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-(New-Object Net.WebClient).DownloadFile('https://github.com/appveyor/secure-file/releases/download/1.0.0/secure-file.zip', $zipPath)
+(New-Object Net.WebClient).DownloadFile('https://github.com/jeff-winn/secure-file/releases/download/1.1.0/secure-file.zip', $zipPath)
 Expand-Archive $zipPath -DestinationPath (Join-Path (pwd).path "appveyor-tools") -Force
 if ($isLinux) {
 	chmod +x ./appveyor-tools/secure-file

--- a/secure-file/ApplicationContext.cs
+++ b/secure-file/ApplicationContext.cs
@@ -1,0 +1,125 @@
+using System;
+
+namespace AppVeyor.Tools.SecureFile
+{
+    /// <summary>
+    /// Contains the contextual information for the application.
+    /// </summary>
+    class ApplicationContext
+    {
+        /// <summary>
+        /// Gets or sets the operation.
+        /// </summary>
+        public OperationType Operation { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the secret.
+        /// </summary>
+        public string Secret { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the base64 encoded salt.
+        /// </summary>
+        public string Salt { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the input file name.
+        /// </summary>
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the output file name.
+        /// </summary>
+        public string OutputFileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a FIPS compliant algorithm must be used.
+        /// </summary>
+        public bool RequireFipsCompliance { get; set; }
+
+        public static ApplicationContext Parse(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                throw new Exception("No arguments specified.");
+            }
+
+            var result = new ApplicationContext();
+
+            int pos = 0;
+            while (pos < args.Length)
+            {
+                var p = args[pos];
+                if (p.Equals("-decrypt", StringComparison.OrdinalIgnoreCase))
+                {
+                    // is it last parameter?
+                    if (pos == args.Length - 1)
+                    {
+                        throw new Exception("Input file name is missing.");
+                    }
+                    else
+                    {
+                        result.Operation = OperationType.Decrypt;
+                        result.FileName = args[++pos];
+                    }
+                }
+                else if (p.Equals("-encrypt", StringComparison.OrdinalIgnoreCase))
+                {
+                    // is it last parameter?
+                    if (pos == args.Length - 1)
+                    {
+                        throw new Exception("Input file name is missing.");
+                    }
+                    else
+                    {
+                        result.Operation = OperationType.Encrypt;
+                        result.FileName = args[++pos];
+                    }
+                }
+                else if (p.Equals("-salt", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (pos == args.Length - 1)
+                    {
+                        throw new Exception("The Base64 encoded salt value is missing.");
+                    }
+                    else
+                    {
+                        result.Salt = args[++pos];
+                    }
+                }
+                else if (p.Equals("-secret", StringComparison.OrdinalIgnoreCase))
+                {
+                    // is it last parameter?
+                    if (pos == args.Length - 1)
+                    {
+                        throw new Exception("Secret passphrase is missing.");
+                    }
+                    else
+                    {
+                        result.Secret = args[++pos];
+                    }
+                }
+                else if (p.Equals("-fips", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.RequireFipsCompliance = true;
+                }
+                else if (p.Equals("-out", StringComparison.OrdinalIgnoreCase))
+                {
+                    // is it last parameter?
+                    if (pos == args.Length - 1)
+                    {
+                        throw new Exception("Out file name is missing.");
+                    }
+                    else
+                    {
+                        result.OutputFileName = args[++pos];
+                    }
+                }
+
+                pos++;
+            }
+
+            return result;
+        }
+    }
+}

--- a/secure-file/ApplicationContextValidator.cs
+++ b/secure-file/ApplicationContextValidator.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+
+namespace AppVeyor.Tools.SecureFile
+{
+    /// <summary>
+    /// Validates the application context.
+    /// </summary>
+    class ApplicationContextValidator
+    {
+        /// <summary>
+        /// Performs validation of the application context.
+        /// </summary>
+        /// <param name="context">The contextual information to validate.</param>
+        public void Validate(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            
+            if (context.OutputFileName == null && context.Operation == OperationType.Encrypt)
+            {
+                context.OutputFileName = context.FileName + ".enc";
+            }
+            else if (context.OutputFileName == null && context.Operation == OperationType.Decrypt)
+            {
+                if (Path.GetExtension(context.FileName).Equals(".enc", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.OutputFileName = context.FileName.Substring(0, context.FileName.Length - 4); // trim .enc
+                }
+                else
+                {
+                    context.OutputFileName = context.FileName + ".dec";
+                }
+            }
+
+            var basePath = Environment.CurrentDirectory;
+
+            // convert relative paths to absolute
+            if (!Path.IsPathRooted(context.FileName))
+            {
+                context.FileName = Path.GetFullPath(Path.Combine(basePath, context.FileName));
+            }
+
+            if (!Path.IsPathRooted(context.OutputFileName))
+            {
+                context.OutputFileName = Path.GetFullPath(Path.Combine(basePath, context.OutputFileName));
+            }
+
+            // in and out file names should not be the same
+            if (context.FileName.Equals(context.OutputFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception("Input and output files cannot be the same.");
+            }
+
+            if (!File.Exists(context.FileName))
+            {
+                throw new Exception("File not found: " + context.FileName);
+            }
+        }
+    }
+}

--- a/secure-file/CommandFactory.cs
+++ b/secure-file/CommandFactory.cs
@@ -1,0 +1,37 @@
+using System;
+using AppVeyor.Tools.SecureFile.Commands;
+
+namespace AppVeyor.Tools.SecureFile
+{
+    /// <summary>
+    /// Provides a factory for creating commands.
+    /// </summary>
+    class CommandFactory
+    {
+        /// <summary>
+        /// Creates a command.
+        /// </summary>
+        /// <param name="context">The contextual information for the factory to use when deciding on the command to create.</param>
+        /// <returns>The command instance.</returns>
+        /// <exception cref="NotSupportedException">The operation being created is not supported.</exception>
+        public ICommand Create(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            switch (context.Operation)
+            {
+                case OperationType.Decrypt:
+                    return new DecryptCommand();
+
+                case OperationType.Encrypt:
+                    return new EncryptCommand();
+
+                default:
+                    throw new NotSupportedException($"The operation '{context.Operation}' is not supported.");
+            }
+        }
+    }
+}

--- a/secure-file/Commands/DecryptCommand.cs
+++ b/secure-file/Commands/DecryptCommand.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AppVeyor.Tools.SecureFile.Commands
+{
+    /// <summary>
+    /// Provides a command to decrypt a file.
+    /// </summary>
+    class DecryptCommand : SymmetricAlgorithmCommand
+    {
+        protected override ICryptoTransform CreateTransform(SymmetricAlgorithm algorithm)
+        {
+            if (algorithm == null)
+            {
+                throw new ArgumentNullException(nameof(algorithm));
+            }
+
+            return algorithm.CreateDecryptor();
+        }
+
+        protected override byte[] GetSaltBytes(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (string.IsNullOrWhiteSpace(context.Salt))
+            {
+                Console.WriteLine("WARNING: You are using a hard-coded salt value! Please re-encrypt your data so a randomized salt can be generated (which you will also need to store).");
+
+                // This is to support any files that were encrypted using the previous process.
+                return Encoding.UTF8.GetBytes("{E4E66F59-CAF2-4C39-A7F8-46097B1C461B}");
+            }
+
+            return Convert.FromBase64String(context.Salt);
+        }
+    }
+}

--- a/secure-file/Commands/EncryptCommand.cs
+++ b/secure-file/Commands/EncryptCommand.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Security.Cryptography;
+
+namespace AppVeyor.Tools.SecureFile.Commands
+{
+    /// <summary>
+    /// Provides a command to encrypt a file.
+    /// </summary>
+    class EncryptCommand : SymmetricAlgorithmCommand
+    {
+        /// <summary>
+        /// Identifies the default length of any salt generated.
+        /// </summary>
+        public const int DefaultSaltLength = 38;
+
+        protected override ICryptoTransform CreateTransform(SymmetricAlgorithm algorithm)
+        {
+            if (algorithm == null)
+            {
+                throw new ArgumentNullException(nameof(algorithm));
+            }
+
+            return algorithm.CreateEncryptor();
+        }
+
+        protected override byte[] GetSaltBytes(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                var bytes = new byte[DefaultSaltLength];
+                rng.GetNonZeroBytes(bytes);
+
+                context.Salt = Convert.ToBase64String(bytes);
+
+                return bytes;
+            }
+        }
+    }
+}

--- a/secure-file/Commands/EncryptCommand.cs
+++ b/secure-file/Commands/EncryptCommand.cs
@@ -13,6 +13,13 @@ namespace AppVeyor.Tools.SecureFile.Commands
         /// </summary>
         public const int DefaultSaltLength = 38;
 
+        protected override void OnAfterExecute(ApplicationContext context)
+        {
+            Console.WriteLine($"Salt: {context.Salt}");
+
+            base.OnAfterExecute(context);
+        }
+
         protected override ICryptoTransform CreateTransform(SymmetricAlgorithm algorithm)
         {
             if (algorithm == null)

--- a/secure-file/Commands/SymmetricAlgorithmCommand.cs
+++ b/secure-file/Commands/SymmetricAlgorithmCommand.cs
@@ -21,6 +21,17 @@ namespace AppVeyor.Tools.SecureFile.Commands
                 throw new ArgumentNullException(nameof(context));
             }
 
+            OnExecute(context);
+            OnAfterExecute(context);
+        }
+
+        protected virtual void OnExecute(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             using (var algorithm = CreateAlgorithm(context))
             using (Stream inStream = File.OpenRead(context.FileName), outStream = File.Create(context.OutputFileName))
             {
@@ -30,6 +41,10 @@ namespace AppVeyor.Tools.SecureFile.Commands
                     inStream.CopyTo(cryptoStream);
                 }
             }
+        }
+
+        protected virtual void OnAfterExecute(ApplicationContext context)
+        {
         }
 
         protected abstract ICryptoTransform CreateTransform(SymmetricAlgorithm algorithm);

--- a/secure-file/Commands/SymmetricAlgorithmCommand.cs
+++ b/secure-file/Commands/SymmetricAlgorithmCommand.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace AppVeyor.Tools.SecureFile.Commands
+{
+    /// <summary>
+    /// Provides an abstract command implementation for a symmetric algorithm.
+    /// </summary>
+    abstract class SymmetricAlgorithmCommand : ICommand
+    {
+        /// <summary>
+        /// Identifies the default number of iterations for the PBKDF2 derivation function.
+        /// </summary>
+        public const int DefaultIterationsCount = 10000;
+
+        public void Execute(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            using (var algorithm = CreateAlgorithm(context))
+            using (Stream inStream = File.OpenRead(context.FileName), outStream = File.Create(context.OutputFileName))
+            {
+                using (var transform = CreateTransform(algorithm))
+                using (var cryptoStream = new CryptoStream(outStream, transform, CryptoStreamMode.Write))
+                {
+                    inStream.CopyTo(cryptoStream);
+                }
+            }
+        }
+
+        protected abstract ICryptoTransform CreateTransform(SymmetricAlgorithm algorithm);
+
+        protected virtual SymmetricAlgorithm CreateAlgorithm(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            SymmetricAlgorithm alg = null;
+
+            try
+            {
+                alg = CreateAlgorithmImpl(context);
+                var salt = GetSaltBytes(context);
+
+                using (var pbkdf2 = new Rfc2898DeriveBytes(context.Secret, salt, DefaultIterationsCount))
+                {
+                    alg.Key = pbkdf2.GetBytes(32);
+                    alg.IV = pbkdf2.GetBytes(16);
+                }
+
+                return alg;
+            }
+            catch (Exception)
+            {
+                alg?.Dispose();
+                throw;
+            }
+        }
+
+        protected virtual SymmetricAlgorithm CreateAlgorithmImpl(ApplicationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.RequireFipsCompliance)
+            {
+                return Aes.Create();
+            }
+
+            return Rijndael.Create();
+        }
+
+        protected abstract byte[] GetSaltBytes(ApplicationContext context);
+    }
+}

--- a/secure-file/ICommand.cs
+++ b/secure-file/ICommand.cs
@@ -1,0 +1,14 @@
+namespace AppVeyor.Tools.SecureFile
+{
+    /// <summary>
+    /// Identifies a command which can be executed.
+    /// </summary>
+    interface ICommand
+    {
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="context">The application contextual information for the command to be executed.</param>
+        void Execute(ApplicationContext context);
+    }
+}

--- a/secure-file/OperationType.cs
+++ b/secure-file/OperationType.cs
@@ -1,0 +1,11 @@
+﻿namespace AppVeyor.Tools.SecureFile
+{
+    /// <summary>
+    /// Defines the different type of operations supported.
+    /// </summary>
+    enum OperationType
+    {
+        Encrypt,
+        Decrypt
+    }
+}

--- a/secure-file/Program.cs
+++ b/secure-file/Program.cs
@@ -1,143 +1,58 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AppVeyor.Tools.SecureFile
 {
     class Program
     {
-        private static string Salt = "{E4E66F59-CAF2-4C39-A7F8-46097B1C461B}";
-
         static void Main(string[] args)
         {
-            string operation = null;
-            string fileName = null;
-            string secret = null;
-            string outFileName = null;
-
             try
             {
-                #region parse parameters
-                if (args.Length == 0)
-                {
-                    throw new Exception("No arguments specified.");
-                }
+                var context = ApplicationContext.Parse(args);
+                ValidateApplicationContext(context);
 
-                int pos = 0;
-                while (pos < args.Length)
+                try
                 {
-                    var p = args[pos];
-                    if (p.Equals("-decrypt", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // is it last parameter?
-                        if (pos == args.Length - 1)
-                        {
-                            throw new Exception("Input file name is missing.");
-                        }
-                        else
-                        {
-                            operation = "decrypt";
-                            fileName = args[++pos];
-                        }
-                    }
-                    else if (p.Equals("-encrypt", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // is it last parameter?
-                        if (pos == args.Length - 1)
-                        {
-                            throw new Exception("Input file name is missing.");
-                        }
-                        else
-                        {
-                            operation = "encrypt";
-                            fileName = args[++pos];
-                        }
-                    }
-                    else if (p.Equals("-secret", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // is it last parameter?
-                        if (pos == args.Length - 1)
-                        {
-                            throw new Exception("Secret passphrase is missing.");
-                        }
-                        else
-                        {
-                            secret = args[++pos];
-                        }
-                    }
-                    else if (p.Equals("-out", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // is it last parameter?
-                        if (pos == args.Length - 1)
-                        {
-                            throw new Exception("Out file name is missing.");
-                        }
-                        else
-                        {
-                            outFileName = args[++pos];
-                        }
-                    }
-
-                    pos++;
+                    Execute(context);
                 }
-
-                if (operation == null)
+                catch (CryptographicException)
                 {
-                    throw new Exception("No operation specified. It should be either -encrypt or -decrypt.");
+                    Console.WriteLine("Encountered a cryptographic error while processing the file.");
+                    Environment.Exit(2);
                 }
-                #endregion
-
-                #region validate file names
-                if (outFileName == null && operation == "encrypt")
+                catch (Exception ex)
                 {
-                    outFileName = fileName + ".enc";
+                    Console.WriteLine("Error processing file: " + ex.Message);
+                    Environment.Exit(3);
                 }
-                else if (outFileName == null && operation == "decrypt")
-                {
-                    if (Path.GetExtension(fileName).Equals(".enc", StringComparison.OrdinalIgnoreCase))
-                    {
-                        outFileName = fileName.Substring(0, fileName.Length - 4); // trim .enc
-                    }
-                    else
-                    {
-                        outFileName = fileName + ".dec";
-                    }
-                }
-
-                var basePath = Environment.CurrentDirectory;
-
-                // convert relative paths to absolute
-                if (!Path.IsPathRooted(fileName))
-                {
-                    fileName = Path.GetFullPath(Path.Combine(basePath, fileName));
-                }
-
-                if (!Path.IsPathRooted(outFileName))
-                {
-                    outFileName = Path.GetFullPath(Path.Combine(basePath, outFileName));
-                }
-
-                // in and out file names should not be the same
-                if (fileName.Equals(outFileName, StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new Exception("Input and output files cannot be the same.");
-                }
-
-                if (!File.Exists(fileName))
-                {
-                    throw new Exception("File not found: " + fileName);
-                }
-                #endregion
             }
             catch (Exception ex)
             {
                 Console.WriteLine("Error: " + ex.Message);
+                Console.WriteLine();
 
-                Console.WriteLine(@"
+                WriteSyntaxToConsole();
+
+                Environment.Exit(1);
+            }
+        }
+
+        private static void ValidateApplicationContext(ApplicationContext context)
+        {
+            var validator = new ApplicationContextValidator();
+            validator.Validate(context);
+        }
+
+        private static void Execute(ApplicationContext context)
+        {
+            var command = new CommandFactory().Create(context);
+            command.Execute(context);
+        }
+
+        private static void WriteSyntaxToConsole()
+        {
+            Console.WriteLine(@"
 USAGE:
 
 Encrypting file:
@@ -146,83 +61,8 @@ Encrypting file:
 
 Decrypting file:
 
-    secure-file -decrypt <filename.ext.enc> -secret <keyphrase> -out [filename.ext]
+    secure-file -decrypt <filename.ext.enc> -secret <keyphrase> -salt [value] -out [filename.ext]
 ");
-                Environment.Exit(1);
-            }
-
-            if (operation == "encrypt")
-            {
-                try
-                {
-                    Encrypt(fileName, outFileName, secret);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine("Error encrypting file: " + ex.Message);
-                    Environment.Exit(2);
-                }
-            }
-            else if (operation == "decrypt")
-            {
-                try
-                {
-                    Decrypt(fileName, outFileName, secret);
-                }
-                catch (CryptographicException)
-                {
-                    Console.WriteLine("Error decrypting file.");
-                    Environment.Exit(3);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine("Error decrypting file: " + ex.Message);
-                    Environment.Exit(3);
-                }
-            }
-        }
-
-        private static void Encrypt(string fileName, string outFileName, string secret)
-        {
-            var alg = GetRijndael(secret);
-
-            using (var inStream = File.OpenRead(fileName))
-            {
-                using (var outStream = File.Create(outFileName))
-                {
-                    using (var cryptoStream = new CryptoStream(outStream, alg.CreateEncryptor(), CryptoStreamMode.Write))
-                    {
-                        inStream.CopyTo(cryptoStream);
-                    }
-                }
-            }
-        }
-
-        private static void Decrypt(string fileName, string outFileName, string secret)
-        {
-            var alg = GetRijndael(secret);
-
-            using (var inStream = File.OpenRead(fileName))
-            {
-                using (var outStream = File.Create(outFileName))
-                {
-                    using (var cryptoStream = new CryptoStream(outStream, alg.CreateDecryptor(), CryptoStreamMode.Write))
-                    {
-                        inStream.CopyTo(cryptoStream);
-                    }
-                }
-            }
-        }
-
-        private static Rijndael GetRijndael(string secret)
-        {
-            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(secret, Encoding.UTF8.GetBytes(Salt), 10000);
-
-            Rijndael alg = Rijndael.Create();
-            alg.Key = pbkdf2.GetBytes(32);
-            alg.IV = pbkdf2.GetBytes(16);
-
-            return alg;
         }
     }
 }


### PR DESCRIPTION
This pull request is to correct issue #2 wherein the salt used is static rather than a randomized value.

About the change... I had to do a bit of restructuring on the code to support what needed to be done, so there will be quite a few new files added, and quite a bit of the logic that was within Main has been lifted out to other classes. Hopefully this will make the tool easier to maintain and make changes to in the future.

A couple things:
- I made sure tool still retains backwards compatibility for decrypt operations only, so it should be a minor upgrade rather than a major. It will also output a warning to the console (thereby showing up in builds) that a static salt was used to decrypt the value. I hope this will get people to re-encrypt their data.
- The salt should be stored within secure environment variables along side the secret and passed into the tool. I've already made the necessary documentation changes to the README.md for this. Normally you'd store the salt near the value, but given the value is a file I made the assumption using another secure environment variable would be better.
- I added FIPS compliance support if required people can use the new -fips option to enable this. This will cause it to use AES instead of Rijndael. Some companies may require using FIPS compliant algorithms.

If you have any questions, please feel free to ask!