### PR TITLE
fix: set executable flag for MacOS (fix #9)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -7,7 +7,7 @@ $zipPath = Join-Path $tempdir 'secure-file.zip'
 [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
 (New-Object Net.WebClient).DownloadFile('https://github.com/appveyor/secure-file/releases/download/1.0.1/secure-file.zip', $zipPath)
 Expand-Archive $zipPath -DestinationPath (Join-Path (pwd).path "appveyor-tools") -Force
-if ($isLinux) {
+if (-Not ($isWindows)) {
 	chmod +x ./appveyor-tools/secure-file
 }
 del $tempdir -Recurse -Force


### PR DESCRIPTION
Replace check for Linux with check for anything but Windows so that the block applies to MacOS as well as Linux.
Closes #9
